### PR TITLE
Fix examples in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ $ npm install hexo-clean-css --save
 ``` yaml
 clean_css:
   exclude: 
-    - *.min.css
+    - '*.min.css'
 ```
 
 - **exclude**: Exclude files


### PR DESCRIPTION
fix #57
Yaml parser will interpret '*' as a special syntax and produce this error:

```
FATAL YAMLException: unidentified alias ".min.css" at line 88, column 16:
        - *.min.css
                   ^
    at generateError (/blog/node_modules/js-yaml/lib/js-yaml/loader.js:167:10)
    at throwError (/blog/node_modules/js-yaml/lib/js-yaml/loader.js:173:9)
    at readAlias (/blog/node_modules/js-yaml/lib/js-yaml/loader.js:1276:5)
    at composeNode (/blog/node_modules/js-yaml/lib/js-yaml/loader.js:1368:20)
    at readBlockMapping (/blog/node_modules/js-yaml/lib/js-yaml/loader.js:1036:16)
    at composeNode (/blog/node_modules/js-yaml/lib/js-yaml/loader.js:1359:12)
    at readBlockSequence (/blog/node_modules/js-yaml/lib/js-yaml/loader.js:955:5)
    at composeNode (/blog/node_modules/js-yaml/lib/js-yaml/loader.js:1358:12)
    at readBlockMapping (/blog/node_modules/js-yaml/lib/js-yaml/loader.js:1089:11)
    at composeNode (/blog/node_modules/js-yaml/lib/js-yaml/loader.js:1359:12)
    at readBlockMapping (/blog/node_modules/js-yaml/lib/js-yaml/loader.js:1089:11)
    at composeNode (/blog/node_modules/js-yaml/lib/js-yaml/loader.js:1359:12)
    at readDocument (/blog/node_modules/js-yaml/lib/js-yaml/loader.js:1525:3)
    at loadDocuments (/blog/node_modules/js-yaml/lib/js-yaml/loader.js:1588:5)
    at Object.load (/blog/node_modules/js-yaml/lib/js-yaml/loader.js:1614:19)
    at Hexo.yamlHelper (/blog/node_modules/hexo/lib/plugins/renderer/yaml.js:7:15) {
  reason: 'unidentified alias ".min.css"',
```